### PR TITLE
Remove analogin_s definition from objects.h

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/objects.h
@@ -54,12 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct analogin_s {
-    ADCName adc;
-    PinName pin;
-    uint32_t channel;
-};
-
 struct can_s {
     CANName can;
     int index;


### PR DESCRIPTION
This PR is intended to fix the latest travis CI build fail (see https://travis-ci.org/ARMmbed/mbed-os/builds/259415947?utm_source=github_status&utm_medium=notification).

The structure `analogin_s` is defined both in [TARGET_STM32L4/common_objects.h](https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_STM/TARGET_STM32L4/common_objects.h#L119) and [TARGET_STM32L496xG/objects.h](https://github.com/ARMmbed/mbed-os/blob/597bb6fced2d742b928d457bab2d77bf1e36735f/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/objects.h#L57). As a result, it must be removed from `objects.h `to fit into `common_objects.h` (as in commit https://github.com/ARMmbed/mbed-os/commit/597bb6fced2d742b928d457bab2d77bf1e36735f concerning `dac_s` structure)

**Note:** Before merging the branch, make sure that the command `python tools/build.py -m NUCLEO_L496ZG -t GCC_ARM -j 4 -c --silent --dsp` doesn't result in an error.

